### PR TITLE
Patch support for extensions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,16 @@ Align the columns to match the surrounding rows (use spaces to pad to the same c
 
 ---
 
+## Patching an extension
+
+When an extension needs a local fix that isn't upstream yet, don't fork it — add a patch under `patches/<slug>/` instead. See `patches/README.md` for the format. It's applied automatically by `patch_extension` (called from `install_extension` in `entrypoint.sh`) on every install/update, so no wiring is needed elsewhere.
+
+```sh
+git diff > patches/<slug>/001-short-description.patch
+```
+
+---
+
 ### Checklist
 
 - [ ] `extensions.sh` — `install_extension` line added in alphabetical order

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN set -ex \
 
 COPY --chown=comfyui --chmod=0755 ./entrypoint.sh .
 COPY --chown=comfyui --chmod=0644 ./extensions.sh .
+COPY --chown=comfyui ./patches ./patches
 
 EXPOSE 8188
 ENTRYPOINT ["/opt/comfyui/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,6 +37,48 @@ function install_extension() {
           && git fetch --prune --prune-tags --recurse-submodules \
           && git reset --hard --recurse-submodules "@{upstream}")
     fi
+
+    # Re-applied on every install/update since a fresh clone or hard reset
+    # always lands on unpatched upstream code.
+    patch_extension "${name}"
+}
+
+# Apply local patches on top of an extension, if any exist.
+#
+# Patches live in "patches/<name>/*.patch" as git-diff files (e.g. generated
+# with `git diff > patches/<name>/001-description.patch` from inside the
+# extension's clone) and are applied in lexical order, so number them
+# (001-, 002-, ...) when an extension needs more than one. Extensions with no
+# patches directory are left untouched.
+function patch_extension() {
+    local name="$1"; shift
+    local patch_dir="${COMFYUI_HOME}/patches/${name}"
+    local ext_dir="${COMFYUI_HOME}/app/custom_nodes/${name}"
+
+    if [[ ! -d "${patch_dir}" ]]; then
+      return 0
+    fi
+
+    if [[ ! -d "${ext_dir}" ]]
+    then
+        log "Cannot patch ${name}: extension is not installed"
+        return 1
+    fi
+
+    local patch_file
+    for patch_file in "${patch_dir}"/*.patch
+    do
+        [[ -e "${patch_file}" ]] || continue
+
+        if (cd "${ext_dir}" && git apply --check --reverse "${patch_file}" 2>/dev/null)
+        then
+            log "Patch $(basename "${patch_file}") already applied to ${name}, skipping..."
+            continue
+        fi
+
+        log "Applying patch $(basename "${patch_file}") to ${name}..."
+        (cd "${ext_dir}" && git apply "${patch_file}")
+    done
 }
 
 function remove_extension() {

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,45 @@
+# Extension patches
+
+Some extensions occasionally need a small local fix that isn't merged
+upstream yet (a bug fix, a compatibility tweak, ...). Rather than forking the
+extension, drop a patch here and it will be applied automatically every time
+the extension is installed or updated (see `patch_extension` in
+`entrypoint.sh`).
+
+## Layout
+
+```
+patches/
+└── <slug>/
+    ├── 001-short-description.patch
+    └── 002-another-fix.patch
+```
+
+- `<slug>` must match the extension's `install_extension` slug in
+  `extensions.sh`.
+- Patch files are applied in lexical order, hence the numeric prefix.
+- An extension with no `patches/<slug>/` directory is left untouched.
+
+See `_example/001-fix-deprecated-numpy-alias.patch` for a worked example
+(fixing a `np.float` deprecated-alias crash in a fictitious node) — copy its
+layout, renaming `_example` to the real extension's slug. `_example` itself
+is never applied to anything: no extension is named `_example` in
+`extensions.sh`.
+
+## Creating a patch
+
+From inside the extension's clone (e.g.
+`$HOME/HDATA/$BASE_DIR/ComfyUI/custom_nodes/<slug>`), make your fix, then:
+
+```sh
+git diff > /path/to/comfyture.algonix/patches/<slug>/001-short-description.patch
+```
+
+## Notes
+
+- `install_extension` always leaves the extension at a clean upstream state
+  (fresh clone, or `git reset --hard` on update), so patches are re-applied
+  on every container start — no manual reapplication needed.
+- If a patch fails to apply (e.g. upstream changed the patched lines), the
+  container will fail to start with a `git apply` error; refresh the patch
+  against the new upstream code.

--- a/patches/_example/001-fix-deprecated-numpy-alias.patch
+++ b/patches/_example/001-fix-deprecated-numpy-alias.patch
@@ -1,0 +1,11 @@
+diff --git a/nodes.py b/nodes.py
+index 543ed3f..e07a297 100644
+--- a/nodes.py
++++ b/nodes.py
+@@ -7,5 +7,5 @@ class ExampleUpscaleNode:
+ 
+     def process(self, image, scale):
+         array = image.cpu().numpy()
+-        array = array.astype(np.float)
++        array = array.astype(np.float32)
+         return (torch.from_numpy(array * scale),)

--- a/patches/comfyui-ollama/001-fix-context-keyerror.patch
+++ b/patches/comfyui-ollama/001-fix-context-keyerror.patch
@@ -1,0 +1,13 @@
+diff --git a/CompfyuiOllama.py b/CompfyuiOllama.py
+index baa8025..ac4a2d5 100644
+--- a/CompfyuiOllama.py
++++ b/CompfyuiOllama.py
+@@ -385,7 +385,7 @@ format: {format}
+             if debug_print:
+                 print("saving context to node memory.")
+ 
+-        return ollama_response_text, ollama_response_thinking, response['context'], meta,
++        return ollama_response_text, ollama_response_thinking, response.get('context', []), meta,
+ 
+ 
+ class OllamaChat:


### PR DESCRIPTION
Some extensions occasionally need a small local fix that isn't merged upstream yet (a bug, a compatibility issue...). Until now the only option was to fork the extension. This PR adds a patch mechanism that's applied automatically on every install/update, without maintaining a fork.

Changes
- entrypoint.sh: new patch_extension function, called from install_extension on every install/update (fresh clone or git reset --hard → upstream code is always "clean", so the patch must be reapplied every time). Applies all .patch files found in patches/<slug>/ in lexical order, idempotently (skips if already applied, via git apply --check --reverse), no-op if the patches/<slug>/ directory doesn't exist.
- patches/README.md: documents the format and the patch-creation workflow (git diff > patches/<slug>/001-description.patch).
- patches/_example/: a fictitious example illustrating the convention (never applied — no extension is named _example).
- patches/comfyui-ollama/001-fix-context-keyerror.patch: first real patch — fixes a KeyError on response['context'] by switching to response.get('context', []).
- Dockerfile: copies the patches/ directory into the image.
- AGENTS.md: new "Patching an extension" section documenting the convention for future contributions.
